### PR TITLE
fix: handle zero-length slice/subarray at end of multi-buffer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,10 @@ export class DynamicBuffer {
       throw new OutOfBoundsError('Out of bounds.')
     }
 
+    if (start === end) {
+      return new DynamicBuffer(EMPTY_BUFFER)
+    }
+
     if (this.buffers.length === 0) {
       return new DynamicBuffer(EMPTY_BUFFER)
     } else if (this.buffers.length === 1) {
@@ -150,6 +154,10 @@ export class DynamicBuffer {
 
     if (start < 0 || start > this.length || end > this.length) {
       throw new OutOfBoundsError('Out of bounds.')
+    }
+
+    if (start === end) {
+      return EMPTY_BUFFER
     }
 
     if (this.buffers.length === 0) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -205,6 +205,16 @@ test('subarray', () => {
     deepStrictEqual(sub.buffer, Buffer.from([5]))
   }
 
+  {
+    const sub = multiBuffer.subarray(6)
+    deepStrictEqual(sub.buffer, EMPTY_BUFFER)
+  }
+
+  {
+    const sub = multiBuffer.subarray(6, 6)
+    deepStrictEqual(sub.buffer, EMPTY_BUFFER)
+  }
+
   // Test Out of bounds
   throws(
     () => {
@@ -297,6 +307,16 @@ test('slice', () => {
 
     // Only check that the first byte is correct
     strictEqual(slice[0], 5)
+  }
+
+  {
+    const slice = multiBuffer.slice(6)
+    deepStrictEqual(slice, EMPTY_BUFFER)
+  }
+
+  {
+    const slice = multiBuffer.slice(6, 6)
+    deepStrictEqual(slice, EMPTY_BUFFER)
   }
 
   // Test Out of bounds


### PR DESCRIPTION
## Summary
- this is the dynamic-buffer side fix for the bug reported in `platformatic/kafka#227` (deserialization failure under load)
- add regression tests for `slice()` and `subarray()` when called at the exact end of a multi-buffer `DynamicBuffer`
- fix both methods by returning early for zero-length ranges (`start === end`) before indexing into `this.buffers[current]`

## Reproduction
This issue can be reproduced with:

```js
const b = new DynamicBuffer([Buffer.from([1]), Buffer.from([2])])
b.slice(2) // throws TypeError before this fix
```

Same for `b.subarray(2)`.

## Verification
- `npm test`
- `npm run lint`
