### PR TITLE
chore: add renovate and npm config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,9 @@
+package-lock=true
+auto-install-peers=true
+strict-peer-dependencies=false
+child-concurrency=1
+resolution-mode=highest
+prefer-symlinked-executables=true
+node-linker=hoisted
+package-import-method=copy
+hoist=false

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "rangeStrategy": "update-lockfile",
+  "ignoreDeps": [
+    "camelcase",
+    "inquirer",
+    "mysql",
+    "swagger-ui-react",
+    "leven",
+    "ora",
+    "graphiql"
+  ],
+  "prHourlyLimit": 1,
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "automerge": true
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
+  "timezone": "Europe/Rome",
+  "schedule": [
+    "* 0-6 * * 6,0"
+  ],
+  "rebaseWhen": "conflicted"
+}


### PR DESCRIPTION
## Summary
- add `renovate.json` using the same baseline configuration as `platformatic/platformatic`
- add `.npmrc` with the same package manager defaults used across Platformatic repos

## Notes
- source for Renovate config: https://github.com/platformatic/platformatic/blob/main/renovate.json

## Verification
- `npm test`
- `npm run lint`
