### PR TITLE
feat: Added readable stream adapter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ console.log(db.buffer) // <Buffer 01 02 03 04 05 06 07 08>
 ### Exports
 
 - `DynamicBuffer`
+- `DynamicBufferReadable`
 - `OutOfBoundsError`
 
 ### Constructor
@@ -101,6 +102,13 @@ Appends chunks from another `DynamicBuffer`. Returns `this`.
 #### `prependFrom(dynamicBuffer)`
 
 Prepends chunks from another `DynamicBuffer`. Returns `this`.
+
+#### `asReadable()`
+
+Returns a `DynamicBufferReadable` stream over the current chunks.
+
+- Streams chunks without concatenating them
+- Snapshots the chunk list when called, so later `append` or `prepend` calls do not affect the stream
 
 ### Data access
 
@@ -199,6 +207,17 @@ message.writeVarInt(payload.length) // payload size
 message.append(payload)
 
 socket.write(message.buffer)
+```
+
+### Streaming a dynamic buffer
+
+```ts
+import { pipeline } from 'node:stream/promises'
+import { DynamicBuffer } from '@platformatic/dynamic-buffer'
+
+const body = new DynamicBuffer([Buffer.from('hello'), Buffer.from(' world')])
+
+await pipeline(body.asReadable(), destination)
 ```
 
 ### Parsing streaming data

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { EMPTY_BUFFER, INT16_SIZE, INT32_SIZE, INT64_SIZE, INT8_SIZE } from './definitions.ts'
+import { DynamicBufferReadable } from './readable.ts'
 import {
   BITS_8PLUS_MASK,
   BITS_8PLUS_MASK_64,
@@ -17,6 +18,7 @@ import {
 const instanceIdentifier = Symbol('plt.dynamicBuffer.instanceIdentifier')
 
 export * from './definitions.ts'
+export * from './readable.ts'
 export * from './varint.ts'
 
 export class OutOfBoundsError extends Error {
@@ -73,6 +75,10 @@ export class DynamicBuffer {
     this.length += buffer.length
 
     return this
+  }
+
+  asReadable (): DynamicBufferReadable {
+    return new DynamicBufferReadable(this.buffers)
   }
 
   prepend (buffer: Buffer): this {

--- a/src/readable.ts
+++ b/src/readable.ts
@@ -1,0 +1,23 @@
+import { Readable } from 'node:stream'
+
+export class DynamicBufferReadable extends Readable {
+  #buffers: Buffer[]
+  #index: number
+
+  constructor (buffers: Buffer[]) {
+    super()
+
+    this.#buffers = buffers.slice()
+    this.#index = 0
+  }
+
+  _read (_size: number): void {
+    while (this.#index < this.#buffers.length) {
+      if (!this.push(this.#buffers[this.#index++])) {
+        return
+      }
+    }
+
+    this.push(null)
+  }
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,8 @@
 import { deepStrictEqual, notStrictEqual, strictEqual, throws } from 'node:assert'
+import { Readable } from 'node:stream'
 import test from 'node:test'
 import { EMPTY_BUFFER } from '../src/definitions.ts'
-import { DynamicBuffer, OutOfBoundsError } from '../src/index.ts'
+import { DynamicBuffer, DynamicBufferReadable, OutOfBoundsError } from '../src/index.ts'
 
 test('static isDynamicBuffer', () => {
   // Test with a DynamicBuffer instance
@@ -59,6 +60,57 @@ test('buffer', () => {
   // Test with multiple Buffers
   const multiBuffer = new DynamicBuffer([Buffer.from([1, 2]), Buffer.from([3, 4])])
   deepStrictEqual(multiBuffer.buffer, Buffer.from([1, 2, 3, 4]))
+})
+
+test('asReadable', async () => {
+  const emptyBuffer = new DynamicBuffer()
+  const emptyReadable = emptyBuffer.asReadable()
+  const emptyChunks: Buffer[] = []
+
+  strictEqual(emptyReadable instanceof DynamicBufferReadable, true)
+  strictEqual(emptyReadable instanceof Readable, true)
+
+  for await (const chunk of emptyReadable) {
+    emptyChunks.push(chunk)
+  }
+
+  deepStrictEqual(emptyChunks, [])
+
+  const singleChunk = Buffer.from([1, 2, 3])
+  const singleBuffer = new DynamicBuffer(singleChunk)
+  const singleChunks: Buffer[] = []
+
+  for await (const chunk of singleBuffer.asReadable()) {
+    singleChunks.push(chunk)
+  }
+
+  strictEqual(singleChunks.length, 1)
+  strictEqual(singleChunks[0], singleChunk)
+  deepStrictEqual(Buffer.concat(singleChunks), singleChunk)
+
+  const multiBuffer = new DynamicBuffer([Buffer.from([1, 2]), Buffer.from([3, 4]), Buffer.from([5, 6])])
+  const multiChunks: Buffer[] = []
+
+  for await (const chunk of multiBuffer.asReadable()) {
+    multiChunks.push(chunk)
+  }
+
+  deepStrictEqual(Buffer.concat(multiChunks), Buffer.from([1, 2, 3, 4, 5, 6]))
+})
+
+test('asReadable snapshots the buffer list', async () => {
+  const dynamicBuffer = new DynamicBuffer([Buffer.from([2]), Buffer.from([3])])
+  const readable = dynamicBuffer.asReadable()
+
+  dynamicBuffer.prepend(Buffer.from([1]))
+  dynamicBuffer.append(Buffer.from([4]))
+
+  const chunks: Buffer[] = []
+  for await (const chunk of readable) {
+    chunks.push(chunk)
+  }
+
+  deepStrictEqual(Buffer.concat(chunks), Buffer.from([2, 3]))
 })
 
 test('append', () => {


### PR DESCRIPTION
## Summary

Added `DynamicBuffer.asReadable()` to expose a zero-copy `Readable` stream over the current `DynamicBuffer` chunks.

## Changes

- Added `DynamicBufferReadable`, a standalone `Readable` subclass.
- Added `DynamicBuffer.asReadable()`.
- Exported `DynamicBufferReadable`.
- Documented `asReadable()` in the README.
- Added tests for:
  - Empty buffers.
  - Single-buffer streaming.
  - Multi-buffer streaming.
  - `Readable` / `DynamicBufferReadable` instance checks.
  - Snapshot behavior when the source `DynamicBuffer` is mutated after `asReadable()` is called.

## Implementation Notes

`DynamicBufferReadable` snapshots the chunk array with `buffers.slice()` when constructed. This means later `append()` or `prepend()` calls do not affect an already-created stream.

The stream does not concatenate or copy buffer contents. It pushes the original `Buffer` chunks and stops when `push()` returns `false`, respecting stream backpressure.

## Assisted By

Assisted-By: OpenAI:GPT-5.5 <openai/gpt-5.5>